### PR TITLE
Make this repo usable directly for PokeTransporterGB

### DIFF
--- a/lib/include/Pokemon.h
+++ b/lib/include/Pokemon.h
@@ -10,11 +10,9 @@
 #include <iomanip>
 #endif
 
-#if !USE_EXTERNALDATA
-// #include "pokemonData.h"
-#endif
-
 #if USE_CPP_RAND
+#include <ctime>
+#include <cstdlib>
 #else
 #include "random.h"
 #endif

--- a/lib/include/pccs_settings.h
+++ b/lib/include/pccs_settings.h
@@ -1,9 +1,25 @@
 #ifndef PCCS_SETTINGS_H
 #define PCCS_SETTINGS_H
 
+#if defined(arm) || defined(__ARM_ARCH)
+// Check for ARMv4T, which is what the ARM7TDMI implements
+#if defined(ARM_ARCH_4T) || (defined(__ARM_ARCH) && (__ARM_ARCH == 4))
+#define ON_GBA true
+#endif
+#endif
+
+#ifndef ON_GBA
 #define ON_GBA false
-#define USE_EXTERNAL_DATA false
+#endif
+
+#if ON_GBA
+#define USE_CPP_RAND false
+#define USE_COMPRESSED_DATA true
+#else
 #define USE_CPP_RAND true
+#define USE_COMPRESSED_DATA false
+#endif
+
 #define ACCESS_POKEDEX false
 
 #endif


### PR DESCRIPTION
These changes allow this repo to be usable directly in PokeTransporterGB as a submodule without the need to manually modify files to make it build.