### PR TITLE
Fix crash caused by corrupted nullMon (thanks to easyaspi314!)

### DIFF
--- a/include/PokeBox.h
+++ b/include/PokeBox.h
@@ -12,11 +12,10 @@ private:
     PokemonTables *table;
     Pokemon *boxStorage[30];
     Pokemon *nullMon;
-    int currIndex = 0;
+    int currIndex;
 
 public:
-    PokeBox();
-    PokeBox(PokemonTables *nTable);
+    PokeBox(PokemonTables *nTable = nullptr);
     void setTable(PokemonTables *nTable);
     bool addPokemon(Pokemon *currPkmn);
     Pokemon *getPokemon(int index);
@@ -27,7 +26,7 @@ public:
     void convertAll();
     int getNumInBox();
     int getNumValid();
-    bool stabilize_mythical = false;
+    bool stabilize_mythical;
 
     bool getContainsMythical();
     bool getContainsInvalid();

--- a/source/PokeBox.cpp
+++ b/source/PokeBox.cpp
@@ -7,9 +7,14 @@
 #include "ptgb_save_data_manager.h"
 #endif
 
-PokeBox::PokeBox() { nullMon = new Pokemon(); }
-
-PokeBox::PokeBox(PokemonTables *nTable) { table = nTable; }
+PokeBox::PokeBox(PokemonTables *nTable)
+    : table(nTable)
+    , boxStorage()
+    , nullMon(new Pokemon())
+    , currIndex(0)
+    , stabilize_mythical(false)
+{
+}
 
 void PokeBox::setTable(PokemonTables *nTable) { table = nTable; }
 


### PR DESCRIPTION
When requesting an index outside of the filled in range of the PokeBox, the code would return nullMon.

nullMon is supposedly initialized as a dummy Pokemon() instance.

However, if you'd use the PokeTables constructor of PokeBox, it wouldn't actually initialize nullMon.

Therefore doing anything with the returned instance could end up crashing. (undefined behavior)

All credits go to easyaspi314, as she did the grunt work of tracking down the bug.